### PR TITLE
Adds Katana citation to the form

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -90,3 +90,15 @@ attributes:
             Please cite the above DOI and include this following acknowledgement in any publication that uses this resource:
             <i>"The authors acknowledge use of facilities in the Structural Biology Facility within the Mark Wainwright Analytical Centre – UNSW,</i>
             <i>funded in part by the Australian Research Council Linkage Infrastructure, Equipment and Facilities Grant: ARC LIEF <b>190100165</b>"</i>
+
+    katana_citation:
+        label: "Katana HPC Citation"
+        class: "d-none"
+        help: |
+            <b>If you use Katana for a paper please cite it using the DOI <a href="https://doi.org/10.26190/669x-a286">10.26190/669X-A286</a>.</b>
+            <br>
+            To see it in the format that you require visit <a href="https://citation.crosscite.org">citation.crosscite.org</a> or use one of the examples below:
+            <ul>
+                <li>Katana. Published online 2010. doi:10.26190/669X-A286</li>
+                <li>Katana. (2010) doi:10.26190/669X-A286.</li>
+            </ul>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -5,6 +5,7 @@ form:
     - prot_mode
     - full_dbs
     - citation_request
+    - katana_citation
 
 cluster: "katana"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -140,7 +140,7 @@ else
     FULL_DB="false"
 fi
 
-[[ "<%= context.af_method %>" == "af2"  ]] && PROT_MODE="alphafold2" && ARGS="--alphafold2_db ${DB_PATH} --alphafold2_model_preset ${prot_mode} --full_dbs ${FULL_DB} --alphafold2_mode split_msa_prediction"
+[[ "<%= context.af_method %>" == "af2"  ]] && PROT_MODE="alphafold2" && ARGS="--alphafold2_db ${DB_PATH} --alphafold2_model_preset ${prot_mode} --alphafold2_full_dbs ${FULL_DB} --alphafold2_mode split_msa_prediction"
 [[ "<%= context.af_method %>" == "cf"   ]] && PROT_MODE="colabfold" && ARGS="--colabfold_db ${DB_PATH}"
 [[ "<%= context.af_method %>" == "esmf" ]] && PROT_MODE="esmfold" && ARGS="--esmfold_db ${DB_PATH} --esmfold_model_preset ${prot_mode}"
 [[ "<%= context.af_method %>" == "rfaa" ]] && PROT_MODE="rosettafold_all_atom" && ARGS="--rosettafold_all_atom_db ${DB_PATH}"


### PR DESCRIPTION
- Adds the Katana citation request to the input form
- Updates the `--full_dbs` flag to `--alphafold2_full_dbs` as is used in the latest proteinfold version

Users who access the app directly will miss the MOTD with the Katana citation. This ensures they will always see the reminder.